### PR TITLE
Add missing dependencies and mood engine service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,8 +29,8 @@ sudo sed -i 's/^#Color/Color/' /etc/pacman.conf
 sudo sed -i 's/^#ParallelDownloads = 5/ParallelDownloads = 5/' /etc/pacman.conf
 
 PACKAGES=(
-  "base-devel" "git" "gnu-free-fonts" "xdg-user-dirs" \
-  "waybar" "wofi" "rofi-wayland" "swaync" \
+  "base-devel" "git" "stow" "gnu-free-fonts" "xdg-user-dirs" \
+  "waybar" "wofi" "rofi-wayland" "swaync" "swaylock" \
   "wallust" "pywal" "swww" "mpv" "mpvpaper" \
   "wezterm" "kitty" "thunar" "grim" "slurp" "swappy" \
   "wf-recorder" "cliphist" "cava" "jq" "imagemagick" "sox" "aubio" \
@@ -38,12 +38,13 @@ PACKAGES=(
   "papirus-icon-theme" "papirus-folders" "btop" "fastfetch" "yazi" \
   "playerctl" "wireplumber" "xdg-desktop-portal-gtk" "sdl2" "gum" \
   "hyprcursor" "hyprpaper" "xdg-desktop-portal-hyprland" \
-  "xdg-desktop-portal-wlr" "swayimg"
+  "xdg-desktop-portal-wlr" "swayimg" "curl" "inkscape" \
+  "networkmanager" "yq" "gettext"
 )
 
 # install yay if not present
 if ! command -v yay >/dev/null; then
-  sudo pacman -S --needed --noconfirm base-devel git
+  sudo pacman -S --needed --noconfirm base-devel git stow
   git clone https://aur.archlinux.org/yay-bin.git /tmp/yay-bin
   pushd /tmp/yay-bin >/dev/null
   makepkg -si --noconfirm
@@ -73,7 +74,9 @@ else
 fi
 
 # services
-systemctl --user enable --now swww.service swaync.service cliphist.service mood-engine.service wallust.path
+mkdir -p "$HOME/.config/systemd/user"
+cp systemd/user/mood-engine.service systemd/user/mood-engine.timer systemd/user/swww.service "$HOME/.config/systemd/user/"
+systemctl --user enable --now swww.service swaync.service cliphist.service wallust.path mood-engine.timer
 systemctl --user enable --now xdg-desktop-portal-hyprland.service 2>/dev/null || true
 systemctl --user enable --now xdg-desktop-portal-wlr.service 2>/dev/null || true
 

--- a/systemd/user/mood-engine.service
+++ b/systemd/user/mood-engine.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Generate dynamic palette from wallpaper and weather
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/hypraura
+ExecStart=%h/hypraura/scripts/mood-engine
+
+[Install]
+WantedBy=default.target

--- a/systemd/user/mood-engine.timer
+++ b/systemd/user/mood-engine.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run mood-engine periodically
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=10min
+Unit=mood-engine.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/user/swww.service
+++ b/systemd/user/swww.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Swww wallpaper daemon
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/swww-daemon
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$REPO_ROOT"
 
-services=(swww.service swaync.service cliphist.service mood-engine.service wallust.path scenes.timer scenes.service mpvpaper@.service)
+services=(swww.service swaync.service cliphist.service mood-engine.service mood-engine.timer wallust.path scenes.timer scenes.service mpvpaper@.service)
 for srv in "${services[@]}"; do
   systemctl --user disable --now "$srv" 2>/dev/null || true
 done


### PR DESCRIPTION
## Summary
- install additional packages like curl, inkcape, networkmanager, swaylock, yq, gettext and stow
- provide mood-engine systemd service and timer and enable timer during install
- ensure uninstall script stops mood-engine timer
- install stow when bootstrapping yay and ship swww service unit so enabling it succeeds

## Testing
- `bash -n install.sh uninstall.sh scripts/*`
- `scripts/diagnostics >/tmp/diag.log && cat /tmp/diag.log`


------
https://chatgpt.com/codex/tasks/task_e_68a00bc050c88321b4d678d39c78f18e